### PR TITLE
docs: add hint to ansible-lint as an alternative to this script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 
 # Ansible FQCN converter
+
+**As of ansible-lint 6.15.0 (2023-04-21), `ansible-lint --fix fqcn` can also do the following but it will reformat the YAML when rewriting.**
+
 Update ansible tasks, playbooks, handlers etc. to use fully qualified module names (even for ansible builtins) by searching for all known modules that are not in fqcn notation and replacing them with the fqcn name.
 
 In some cases the replacement might be ambiguous, so a warning will be issued (and by default added as a comment to the changed files; see `-W` arg).


### PR DESCRIPTION
Closes: #26
Looks like this: https://github.com/ypid/ansible-fqcn-converter/tree/docs/ansible-lint?tab=readme-ov-file#ansible-fqcn-converter