### PR TITLE
update workflow python (3.11) and pylint (2.16.2)

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: install pylint
         run: |
           python -m pip install --upgrade pip
-          pip install pylint==2.7.2 pyyaml
+          pip install pylint==2.16.2 pyyaml
       - name: run pylint
         run: |
           pylint *.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: install pyyaml
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/testupdatemap.yml
+++ b/.github/workflows/testupdatemap.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: install pyyaml
         run: |
           python -m pip install --upgrade pip

--- a/fqcn-fixer.py
+++ b/fqcn-fixer.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,consider-using-f-string
 
 import sys
 import os


### PR DESCRIPTION
use a more up to date python and pylint version for workflows (use the debian 12 versions)